### PR TITLE
continue render when state is updated

### DIFF
--- a/src/LearnDataFetch/index.tsx
+++ b/src/LearnDataFetch/index.tsx
@@ -92,12 +92,17 @@ export const LearnDataFetch: React.FC<{
     );
     setMessages(messages);
 
-    continueRender(handle);
-  }, [handle]);
-
+  }, []);
+  
   useEffect(() => {
     fetchMessages();
   }, [fetchMessages, handle]);
+  
+  useEffect(() => {
+    if (messages !== null) {
+      continueRender(handle);
+    }
+  }, [handle, messages])
 
   let idsArr = getIndexedArray(JSON.stringify(metadata));
   const frame = useCurrentFrame();


### PR DESCRIPTION
The rerendering of the component when the state is set is super expensive and takes multiple seconds.
Since React updates the state asynchronously, `continueRender()` is actually called before the rerender is visible on the page. We can fix it by waiting until the state has actually been set.